### PR TITLE
fix another typo in the unix module

### DIFF
--- a/module-1-programming/Day2_2_Terminal_Commands_and_Bash_Scripting.ipynb
+++ b/module-1-programming/Day2_2_Terminal_Commands_and_Bash_Scripting.ipynb
@@ -2346,7 +2346,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gzip -d sequences.txt\n",
+    "gzip -d sequences.txt.gz\n",
     "ls"
    ]
   },


### PR DESCRIPTION
decompression of a compressed file should have `.gz` at the end of it